### PR TITLE
Fix activation hook and typewriter navigation

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -78,8 +78,8 @@
     function next(){ idx=(idx+1)%items.length; show(); }
     function prev(){ idx=(idx-1+items.length)%items.length; show(); }
 
-    container.querySelector('.nt-next') && container.querySelector('.nt-next').addEventListener('click', prev);
-    container.querySelector('.nt-prev') && container.querySelector('.nt-prev').addEventListener('click', next);
+    container.querySelector('.nt-next') && container.querySelector('.nt-next').addEventListener('click', next);
+    container.querySelector('.nt-prev') && container.querySelector('.nt-prev').addEventListener('click', prev);
 
     // Keyboard support (left/right)
     container.addEventListener('keydown', (e)=>{

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -11,5 +11,3 @@ function nt_css_vars_inline(){
     echo '<style id="nt-vars">.nt-ticker{'.$vars.'}</style>';
 }
 add_action('wp_head', 'nt_css_vars_inline');
-
-register_activation_hook(__FILE__ , function(){ nt_get_options(); });

--- a/news-ticker.php
+++ b/news-ticker.php
@@ -21,6 +21,12 @@ require_once NT_PATH . 'inc/class-settings.php';
 require_once NT_PATH . 'inc/class-rest.php';
 require_once NT_PATH . 'inc/class-vc.php'; // WPBakery
 
+register_activation_hook(__FILE__, 'nt_activate_plugin');
+
+function nt_activate_plugin(){
+    nt_get_options();
+}
+
 add_action('plugins_loaded', function () {
     load_plugin_textdomain('news-ticker', false, dirname(plugin_basename(__FILE__)).'/languages');
 });


### PR DESCRIPTION
## Summary
- move the activation hook to the main plugin file so default options initialize reliably
- correct the typewriter navigation buttons so Previous/Next actions are wired correctly

## Testing
- php -l news-ticker.php
- php -l inc/helpers.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ecba3250832f92ca4c3fd72edc08